### PR TITLE
No warnings, more security

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -1,6 +1,6 @@
 use ExtUtils::MakeMaker;
 
-my %http_module = (Furl => '0.42');
+my %http_module = (Furl => '1.01');
 eval {
     require Furl::HTTP;
 };if ($@) {

--- a/lib/WebService/Dropbox.pm
+++ b/lib/WebService/Dropbox.pm
@@ -37,6 +37,7 @@ $WebService::Dropbox::USE_LWP = 0;
 sub import {
     eval {
         require Furl::HTTP;
+        require IO::Socket::SSL;
     };if ($@) {
         require LWP::UserAgent;
         require HTTP::Request;
@@ -485,7 +486,10 @@ sub furl {
     my $self = shift;
     unless ($self->{furl}) {
         $self->{furl} = Furl::HTTP->new(
-            timeout => $self->timeout
+            timeout => $self->timeout,
+            ssl_opts => {
+                SSL_verify_mode => IO::Socket::SSL::SSL_VERIFY_PEER(),
+            },
         );
     }
     $self->{furl};


### PR DESCRIPTION
Furl 1.01 supports `ssl_opts` to pass SSL configuration. This pull-req uses it for security; and as a result, warnings produced by IO::Socket::SSL will dismiss.
