### PR TITLE
Allow for partial file download via HTTP range header parameter.

### DIFF
--- a/lib/WebService/Dropbox.pm
+++ b/lib/WebService/Dropbox.pm
@@ -441,6 +441,9 @@ sub api_lwp {
         my $content_length = $end_pos - $cur_pos;
         push @$headers, 'Content-Length' => $content_length;
     }
+    if ($args->{range}) {
+        push @$headers, 'Range' => $args->{range};
+    }
     my $req = HTTP::Request->new($args->{method}, $args->{url}, $headers, $args->{content});
     my $ua = LWP::UserAgent->new;
     $ua->timeout($self->timeout);


### PR DESCRIPTION
Add HTTP Range parameter support to api_lwp for use with DropBox /files API.

Usage:

$dropbox->files($dropbox_source_path, $some_file_path, {}, { range => "bytes=$start_byte-$end_byte" });
