### PR TITLE
Addition of refresh_access_token and initial version of Sharing support for links to shared files

### DIFF
--- a/lib/WebService/Dropbox.pm
+++ b/lib/WebService/Dropbox.pm
@@ -11,7 +11,7 @@ use WebService::Dropbox::Files;
 use WebService::Dropbox::Files::CopyReference;
 use WebService::Dropbox::Files::ListFolder;
 use WebService::Dropbox::Files::UploadSession;
-# use WebService::Dropbox::Sharing; comming soon...
+use WebService::Dropbox::Sharing;
 use WebService::Dropbox::Users;
 
 our $VERSION = '2.07';

--- a/lib/WebService/Dropbox/Auth.pm
+++ b/lib/WebService/Dropbox/Auth.pm
@@ -45,6 +45,30 @@ sub token {
     $data;
 }
 
+# https://www.dropbox.com/developers/documentation/http/documentation#oauth2-token
+# This uses the token method with a refresh token to get an updated access token.
+sub refresh_access_token {
+    my ($self, $refresh_token) = @_;
+
+    my $data = $self->api({
+        url => 'https://api.dropboxapi.com/oauth2/token',
+        params => {
+            client_id     => $self->key,
+            client_secret => $self->secret,
+            grant_type    => 'refresh_token',
+            refresh_token => $refresh_token,
+        },
+    });
+
+    # at this point the access token should be in $data
+    # so set it like WebService::Dropbox::Auth::token does
+    if ($data && $data->{access_token}) {
+        $self->access_token($data->{access_token});
+    }
+
+    $data;
+}
+
 # https://www.dropbox.com/developers/documentation/http/documentation#auth-token-revoke
 sub revoke {
     my ($self) = @_;

--- a/lib/WebService/Dropbox/Sharing.pm
+++ b/lib/WebService/Dropbox/Sharing.pm
@@ -1,0 +1,76 @@
+package WebService::Dropbox::Sharing;
+use strict;
+use warnings;
+use parent qw(Exporter);
+
+our @EXPORT = do {
+    no strict 'refs';
+    grep { $_ =~ qr{ \A [a-z] }xms } keys %{ __PACKAGE__ . '::' };
+};
+
+# https://www.dropbox.com/developers/documentation/http/documentation#sharing-create_shared_link_with_settings
+sub create_shared_link_with_settings {
+    my ($self, $file, $settings) = @_;
+
+    my $params = {
+        path     => $file,
+        settings => $settings,
+    };
+
+    $self->api({
+        url => 'https://api.dropboxapi.com/2/sharing/create_shared_link_with_settings',
+        params => $params,
+    });
+}
+
+# https://www.dropbox.com/developers/documentation/http/documentation#sharing-list_shared_links
+sub list_shared_links {
+    my ($self, $file) = @_;
+
+    my $params = {
+        path     => $file,
+    };
+
+    $self->api({
+        url => 'https://api.dropboxapi.com/2/sharing/list_shared_links',
+        params => $params,
+    });
+}
+
+# https://www.dropbox.com/developers/documentation/http/documentation#sharing-modify_shared_link_settings
+sub modify_shared_link_settings {
+    my ($self, $file, $settings, $remove_expiration) = @_;
+
+	if ($remove_expiration) {
+		$remove_expiration = 1;
+	} else {
+		$remove_expiration = 0;
+	}
+
+    my $params = {
+        path     => $file,
+        settings => $settings,
+        remove_expiration => $remove_expiration,
+    };
+
+    $self->api({
+        url => 'https://api.dropboxapi.com/2/sharing/modify_shared_link_settings',
+        params => $params,
+    });
+}
+
+# https://www.dropbox.com/developers/documentation/http/documentation#sharing-revoke_shared_link
+sub revoke_shared_link {
+    my ($self, $url) = @_;
+
+    my $params = {
+        url      => $url,
+    };
+
+    $self->api({
+        url => 'https://api.dropboxapi.com/2/sharing/revoke_shared_link',
+        params => $params,
+    });
+}
+
+1;

--- a/lib/WebService/Dropbox/Sharing.pm
+++ b/lib/WebService/Dropbox/Sharing.pm
@@ -3,6 +3,9 @@ use strict;
 use warnings;
 use parent qw(Exporter);
 
+## preliminary version with support for creating and managing links
+## to shared files. more to follow...
+
 our @EXPORT = do {
     no strict 'refs';
     grep { $_ =~ qr{ \A [a-z] }xms } keys %{ __PACKAGE__ . '::' };
@@ -10,10 +13,10 @@ our @EXPORT = do {
 
 # https://www.dropbox.com/developers/documentation/http/documentation#sharing-create_shared_link_with_settings
 sub create_shared_link_with_settings {
-    my ($self, $file, $settings) = @_;
+    my ($self, $path, $settings) = @_;
 
     my $params = {
-        path     => $file,
+        path     => $path,
         settings => $settings,
     };
 
@@ -25,10 +28,10 @@ sub create_shared_link_with_settings {
 
 # https://www.dropbox.com/developers/documentation/http/documentation#sharing-list_shared_links
 sub list_shared_links {
-    my ($self, $file) = @_;
+    my ($self, $path) = @_;
 
     my $params = {
-        path     => $file,
+        path     => $path,
     };
 
     $self->api({
@@ -39,8 +42,9 @@ sub list_shared_links {
 
 # https://www.dropbox.com/developers/documentation/http/documentation#sharing-modify_shared_link_settings
 sub modify_shared_link_settings {
-    my ($self, $file, $settings, $remove_expiration) = @_;
+    my ($self, $path, $settings, $remove_expiration) = @_;
 
+    # this assumes the api converts 1 and 0 to JSON::true and JSON::false accordingly
 	if ($remove_expiration) {
 		$remove_expiration = 1;
 	} else {
@@ -48,7 +52,7 @@ sub modify_shared_link_settings {
 	}
 
     my $params = {
-        path     => $file,
+        path     => $path,
         settings => $settings,
         remove_expiration => $remove_expiration,
     };

--- a/t/15_auth.t
+++ b/t/15_auth.t
@@ -1,0 +1,43 @@
+use strict;
+use Test::More;
+use WebService::Dropbox;
+
+if (!$ENV{'DROPBOX_APP_KEY'} or !$ENV{'DROPBOX_APP_SECRET'} or !$ENV{'DROPBOX_REFRESH_TOKEN'}) {
+    plan skip_all => 'missing App Key, App Secret, and/or Refresh Token';
+}
+
+
+my $dropbox = WebService::Dropbox->new({
+    key       => $ENV{'DROPBOX_APP_KEY'},
+    secret    => $ENV{'DROPBOX_APP_SECRET'},
+    env_proxy => 1,
+});
+
+$dropbox->debug;
+$dropbox->verbose;
+
+### initial authorization to get a refresh token
+#my $url = $dropbox->authorize({ token_access_type => 'offline' });
+#print "Go To $url\n";
+#print "Enter code : ";
+#chomp( my $code = <STDIN> );
+#my $result = $dropbox->token($code) or die $dropbox->error;
+#printf("Refresh Token: %s\nAccess Token: %s\n", $result->{'refresh_token'}, $result->{'access_token'});
+#$VAR1 = {
+#          'account_id' => '...',
+#          'uid' => '...',
+#          'refresh_token' => '...',
+#          'scope' => 'account_info.read files.content.read files.metadata.read sharing.read ...',
+#          'expires_in' => 14399,
+#          'token_type' => 'bearer',
+#          'access_token' => '...',
+#        };
+
+## Test getting an access token when you only have the refresh token
+my $result = $dropbox->refresh_token($ENV{'DROPBOX_REFRESH_TOKEN'}) or die $dropbox->error;
+is $dropbox->res->code, 200;
+is $result->{'token_type'}, 'bearer';
+my $token = $result->{'access_token'};
+like $token, qr/\S+/;
+
+done_testing();

--- a/t/15_auth.t
+++ b/t/15_auth.t
@@ -34,7 +34,7 @@ $dropbox->verbose;
 #        };
 
 ## Test getting an access token when you only have the refresh token
-my $result = $dropbox->refresh_token($ENV{'DROPBOX_REFRESH_TOKEN'}) or die $dropbox->error;
+my $result = $dropbox->refresh_access_token($ENV{'DROPBOX_REFRESH_TOKEN'}) or die $dropbox->error;
 is $dropbox->res->code, 200;
 is $result->{'token_type'}, 'bearer';
 my $token = $result->{'access_token'};

--- a/t/50_sharing.t
+++ b/t/50_sharing.t
@@ -1,0 +1,52 @@
+use strict;
+use Test::More;
+use IO::File;
+use File::Basename qw(dirname);
+use File::Spec;
+use WebService::Dropbox;
+
+if (!$ENV{'DROPBOX_APP_KEY'} or !$ENV{'DROPBOX_APP_SECRET'} or !$ENV{'DROPBOX_ACCESS_TOKEN'}) {
+    plan skip_all => 'missing App Key, App Secret, and/or Access Token';
+}
+
+my $testfile = File::Spec->catfile(dirname(__FILE__), 'sample.png');
+my $path     = '/work/sharing-test-sample.png';
+
+if (! -r $testfile) {
+    plan skip_all => 'missing sample.png';
+}
+
+my $dropbox = WebService::Dropbox->new({
+    key => $ENV{'DROPBOX_APP_KEY'},
+    secret => $ENV{'DROPBOX_APP_SECRET'},
+    access_token => $ENV{'DROPBOX_ACCESS_TOKEN'},
+    env_proxy => 1,
+});
+
+$dropbox->debug;
+$dropbox->verbose;
+
+my $fh = IO::File->new($testfile, 'r');
+$dropbox->upload($path, $fh) or die $dropbox->error;
+$fh->close;
+
+## create a shared link to the test file
+my $settings = {
+	requested_visibility => 'public',
+	audience => 'public',
+	access => 'viewer'
+};
+my $result = $dropbox->create_shared_link_with_settings($path, $settings) or die $dropbox->error;
+is $dropbox->res->code, 200;
+
+## list the shared links with test file
+$result = $dropbox->list_shared_links($path) or die $dropbox->error;
+is $dropbox->res->code, 200;
+
+## revoke shared links with test file
+my $revoke = $dropbox->revoke_shared_link($result->{'links'}->[0]->{'url'}) or die $dropbox->error;
+is $dropbox->res->code, 200;
+
+$dropbox->delete($path) or die $dropbox->error;
+
+done_testing();


### PR DESCRIPTION
Adds ability to refresh access token using the refresh token.
Adds Sharing API calls to support creating and managing links to shared files.
    Primitive support, could be made better.
    Additional sharing calls to be added as time permits.
